### PR TITLE
Updated tests to use release configuration.

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --configuration Release
       - name: Run tests
-        run: dotnet test --no-build --verbosity normal
+        run: dotnet test --no-build --verbosity normal --configuration Release
       - name: Update version
         run: |
           NEW_VERSION=${GITHUB_REF#refs/tags/v}


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/nuget-publish.yml` file. The change ensures that the tests are run in the Release configuration.

* [`.github/workflows/nuget-publish.yml`](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4L22-R22): Modified the `Run tests` step to include `--configuration Release` in the `dotnet test` command.