### PR TITLE
Fixing stream overload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
-## [1.2.0] - Unreleased
+## [1.2.0] - 2025-02-28
 
 ### Added
 
 - **Nested Polymorphic Types:** Added support for hierarchical type resolution with multiple levels of polymorphic types
 
+### Fixed
+
+- **Fixing issue with streams:** Fixed the way streams are handled.
 
 ## [1.1.0] - 2025-02-20
 


### PR DESCRIPTION
This pull request includes updates to the `CHANGELOG.md` file and several improvements to the `YamlParser` class in the `src/YAYL` directory. The most important changes include updating the release date in the changelog, simplifying the `NormalizeEnumValueName` method, and improving the handling of asynchronous parsing in the `YamlParser` class.

### Changelog Update:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R11): Updated the release date for version 1.2.0 and added a fix for stream handling.

### Code Simplification:
* [`src/YAYL/YamlParser.cs`](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eL49-R49): Simplified the `NormalizeEnumValueName` method by converting it to an expression-bodied member.

### Asynchronous Parsing Improvements:
* [`src/YAYL/YamlParser.cs`](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eL211-R240): Improved the `ParseAsync` method to handle null or empty streams more efficiently and refactored the method to use `Task.FromResult` for returning null results.
* [`src/YAYL/YamlParser.cs`](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eL211-R240): Added a new private asynchronous method `ParseAsync` that takes a `TextReader` as a parameter to streamline the parsing process.