### PR TITLE
Adding support for sets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.5.0] - 2025-05-09
+
+- **Parser support for Sets:** Adding support for parsing set types (`ISet<T>`, `HashSet<T>`, and `SortedSet<T>`)
+
 ## [1.4.0] - 2025-05-05
 
 - **YamlDerivedTypeDefaultAttribute:** Adding attribute to enable fallback type for discriminated type.

--- a/test/YAYL.Tests/YamlParserTests.cs
+++ b/test/YAYL.Tests/YamlParserTests.cs
@@ -336,7 +336,10 @@ public partial class YamlParserTests
         List<string> StringList,
         IList<int> IntList,
         ICollection<double> DoubleCollection,
-        IEnumerable<bool> BoolEnumerable
+        IEnumerable<bool> BoolEnumerable,
+        ISet<string> StringSet,
+        HashSet<string> StringHashSet,
+        SortedSet<string> StringSortedSet
     );
 
     [Fact]
@@ -354,7 +357,16 @@ public partial class YamlParserTests
                 - 2.2
             bool-enumerable:
                 - true
-                - false";
+                - false
+            string-set:
+                - one
+                - two
+            string-hash-set:
+                - three
+                - four
+            string-sorted-set:
+                - five
+                - six";
 
         var result = _parser.Parse<ListContainer>(yaml);
 
@@ -363,6 +375,9 @@ public partial class YamlParserTests
         Assert.Equal([1, 2], result.IntList);
         Assert.Equal([1.1, 2.2], result.DoubleCollection);
         Assert.Equal([true, false], result.BoolEnumerable);
+        Assert.Equal(["one", "two"], result.StringSet);
+        Assert.Equal(["three", "four"], result.StringHashSet);
+        Assert.Equal(["five", "six"], result.StringSortedSet);
     }
 
     record RequiredProps(bool Required);


### PR DESCRIPTION
This pull request enhances the `YamlParser` to support additional generic collection types and updates the corresponding tests to validate these changes. The most significant updates include replacing the `IsGenericCollection` method with a more flexible `GetGenericCollection` method, adding support for new collection types like `ISet<>`, `HashSet<>`, and `SortedSet<>`, and modifying the test suite to cover these new types.

### Enhancements to `YamlParser` functionality:

* Replaced the `IsGenericCollection` method with a new `GetGenericCollection` method that identifies and returns the appropriate generic collection type (e.g., `List<>`, `HashSet<>`, `SortedSet<>`) or `null` if unsupported. This change improves extensibility and readability.
* Updated the `ConvertToGenericCollectionAsync` method to dynamically instantiate and populate the correct generic collection type based on the new `GetGenericCollection` logic.
* Added a private `AddToGenericCollection` helper method to handle adding elements to generic collections in a type-safe manner.

### Test suite updates:

* Extended the `ListContainer` record in `YamlParserTests` to include new collection types: `ISet<string>`, `HashSet<string>`, and `SortedSet<string>`.
* Enhanced the `Parse_DifferentCollectionTypes_Success` test to include YAML mappings for the new collection types and assertions to verify their correct parsing. [[1]](diffhunk://#diff-5e0ee8f447594108a92678f9ffe624d9dffbd739cae1cc3a8fe1c1c6ddec04f9L357-R369) [[2]](diffhunk://#diff-5e0ee8f447594108a92678f9ffe624d9dffbd739cae1cc3a8fe1c1c6ddec04f9R378-R380)