### PR TITLE
Adding YamlContext and YamlPathFieldAttribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.6.0] - 2025-05-11
 
 - **Adding YamlContext**: New configuration object that can be provided to parse operations.
-- **Adding YamlPathFieldAttribute**: New attribute that to resolve paths to absolute during parse time.
+- **Adding YamlPathFieldAttribute**: New attribute that resolves file paths to absolute paths during parsing.
 
 ## [1.5.0] - 2025-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.6.0] - 2025-05-11
+
+- **Adding YamlContext**: New configuration object that can be provided to parse operations.
+- **Adding YamlPathFieldAttribute**: New attribute that to resolve paths to absolute during parse time.
+
 ## [1.5.0] - 2025-05-09
 
 - **Parser support for Sets:** Adding support for parsing set types (`ISet<T>`, `HashSet<T>`, and `SortedSet<T>`)

--- a/src/YAYL/YamlContext.cs
+++ b/src/YAYL/YamlContext.cs
@@ -1,0 +1,7 @@
+namespace YAYL;
+
+public class YamlContext
+{
+    public string? FilePath {get; init;}
+    public string? WorkingDirectory {get; init;}
+}

--- a/src/YAYL/YamlPathType.cs
+++ b/src/YAYL/YamlPathType.cs
@@ -1,0 +1,7 @@
+namespace YAYL;
+
+public enum YamlFilePathType
+{
+    RelativeToFile,
+    RelativeToCurrentDirectory,
+}

--- a/src/YAYL/attributes/YamlFieldPostProcessingAttribute.cs
+++ b/src/YAYL/attributes/YamlFieldPostProcessingAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace YAYL.Attributes;
+
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
+public abstract class YamlFieldPostProcessingAttribute : Attribute
+{
+    internal abstract object? Process(object? value, Type fieldType, YamlContext? context);
+}

--- a/src/YAYL/attributes/YamlPathFieldAttribute.cs
+++ b/src/YAYL/attributes/YamlPathFieldAttribute.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+
+namespace YAYL.Attributes;
+
+public class YamlPathFieldAttribute(YamlFilePathType pathType = YamlFilePathType.RelativeToFile) : YamlFieldPostProcessingAttribute
+{
+    public readonly YamlFilePathType PathType = pathType;
+
+    internal override object? Process(object? value, Type fieldType, YamlContext? context)
+    {
+        if (value == null)
+        {
+            return null;
+        }
+        if (value is not string stringValue)
+        {
+            throw new YamlParseException($"The PathFieldAttribute can only be applied to string fields. Found {fieldType.Name}.");
+        }
+        switch (PathType)
+        {
+            case YamlFilePathType.RelativeToCurrentDirectory:
+            {
+                return Path.GetFullPath(Path.Combine(context?.WorkingDirectory ?? Environment.CurrentDirectory, stringValue));
+
+            }
+            case YamlFilePathType.RelativeToFile:
+            {
+                if (context?.FilePath == null)
+                {
+                    throw new YamlParseException($"The RelativeToFile path type can not be used when FilePath is not set in the context.");
+                }
+                var fileDirectory = Path.GetDirectoryName(context.FilePath);
+                if (string.IsNullOrWhiteSpace(fileDirectory))
+                {
+                    throw new YamlParseException($"The file path {context.FilePath} is invalid.");
+                }
+                return Path.GetFullPath(Path.Combine(fileDirectory, stringValue));
+            }
+            default:
+                throw new YamlParseException($"Unknown path type: {PathType}.");
+        }
+    }
+}

--- a/test/YAYL.Tests/YamlParserTests.Files.cs
+++ b/test/YAYL.Tests/YamlParserTests.Files.cs
@@ -1,0 +1,190 @@
+using YAYL.Attributes;
+
+namespace YAYL.Tests;
+
+public partial class YamlParserTests: IDisposable
+{
+    private string _tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+    public YamlParserTests()
+    {
+        if (!Directory.Exists(_tempDirectory))
+        {
+            Directory.CreateDirectory(_tempDirectory);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, true);
+        }
+    }
+
+    internal record ObjectWithFilePropertyCurrentDirectory(
+            [property: YamlPathField(YamlFilePathType.RelativeToCurrentDirectory)]
+            string ContentFile
+    );
+
+    internal record ObjectWithFilePropertyFile(
+            [property: YamlPathField(YamlFilePathType.RelativeToFile)]
+            string ContentFile
+    );
+
+
+    [Fact]
+    public void Parse_FileProperty_RelativeToWorkingDirectory()
+    {
+        var yaml = @"content-file: ./content.txt";
+
+        var parser = new YamlParser();
+
+        var result = parser.Parse<ObjectWithFilePropertyCurrentDirectory>(yaml, new(){ WorkingDirectory = _tempDirectory });
+        Assert.NotNull(result);
+        Assert.Equal(Path.Combine(_tempDirectory, "content.txt"), result.ContentFile);
+    }
+
+    [Fact]
+    public void Parse_FileProperty_RelativeToFile()
+    {
+        var yaml = @"content-file: ../content.txt";
+
+        var parser = new YamlParser();
+
+        var result = parser.Parse<ObjectWithFilePropertyFile>(yaml, new(){ FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
+        Assert.NotNull(result);
+        Assert.Equal(Path.Combine(_tempDirectory, "content.txt"), result.ContentFile);
+    }
+
+    [Fact]
+    public void ParseFile_ImplicitFilePath()
+    {
+        using var yamlFile = new TestFile(
+            Path.Combine(_tempDirectory, "subdir", "test.yaml"),
+            "content-file: ../content.txt");
+
+        var parser = new YamlParser();
+        var result = parser.ParseFile<ObjectWithFilePropertyFile>(yamlFile.FilePath);
+
+        Assert.NotNull(result);
+        Assert.Equal(Path.Combine(_tempDirectory, "content.txt"), result.ContentFile);
+    }
+
+    [Fact]
+    public void ParseFile_ExplicitFilePath()
+    {
+        using var yamlFile = new TestFile(Path.Combine(
+                                    _tempDirectory, "test.yaml"),
+                                    "content-file: ../content.txt");
+
+        var parser = new YamlParser();
+        var result = parser.ParseFile<ObjectWithFilePropertyFile>(yamlFile.FilePath,
+         new(){ FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
+
+        Assert.NotNull(result);
+        Assert.Equal(Path.Combine(_tempDirectory, "content.txt"), result.ContentFile);
+    }
+
+    [Fact]
+    public void ParseFile_ImplicitWorkingDirectory()
+    {
+        using TestFile yamlFile = new(
+            Path.Combine(_tempDirectory, "test.yaml"),
+            "content-file: ./subdir/content.txt");
+
+        var parser = new YamlParser();
+
+        using ScopeGuard<string> _e = new(() => {
+            var oldWorkingDirectory = Environment.CurrentDirectory;
+            Environment.CurrentDirectory = _tempDirectory;
+            return oldWorkingDirectory;
+        }, oldWorkingDirectory => {
+            Environment.CurrentDirectory = oldWorkingDirectory;
+        });
+
+        var result = parser.ParseFile<ObjectWithFilePropertyCurrentDirectory>(yamlFile.FilePath);
+
+        Assert.NotNull(result);
+
+        Assert.Equal(Path.Combine(_tempDirectory, "subdir", "content.txt"), result.ContentFile);
+    }
+
+    [Fact]
+    public void ParseFile_ExplicitWorkingDirectory()
+    {
+        using TestFile yamlFile = new(
+            Path.Combine(_tempDirectory, "test.yaml"),
+            "content-file: ./subdir/content.txt");
+
+        var parser = new YamlParser();
+
+        var result = parser.ParseFile<ObjectWithFilePropertyCurrentDirectory>(yamlFile.FilePath,
+            new(){ WorkingDirectory = Path.Combine(_tempDirectory, "other") });
+
+        Assert.NotNull(result);
+        Assert.Equal(Path.Combine(_tempDirectory, "other", "subdir", "content.txt"), result.ContentFile);
+    }
+
+    [Fact]
+    public void Parse_AbsolutePath_CurrentDirectory()
+    {
+        var yaml = @"content-file: /content.txt";
+
+        var parser = new YamlParser();
+
+        var result = parser.Parse<ObjectWithFilePropertyCurrentDirectory>(yaml, new(){ WorkingDirectory = _tempDirectory });
+        Assert.NotNull(result);
+        Assert.Equal("/content.txt", result.ContentFile);
+    }
+
+    [Fact]
+    public void Parse_AbsolutePath_File()
+    {
+        var yaml = @"content-file: /content.txt";
+
+        var parser = new YamlParser();
+
+        var result = parser.Parse<ObjectWithFilePropertyFile>(yaml, new(){ FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
+        Assert.NotNull(result);
+        Assert.Equal("/content.txt", result.ContentFile);
+    }
+
+    internal class TestFile: IDisposable
+    {
+        public readonly string FilePath;
+        public readonly string Content;
+
+        public TestFile(string path, string content)
+        {
+            FilePath = path;
+            Content = content;
+            var directory = Path.GetDirectoryName(path) ?? throw new InvalidOperationException($"Path {path} is invalid.");
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+            File.WriteAllText(path, content);
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(FilePath))
+            {
+                File.Delete(FilePath);
+            }
+        }
+    }
+
+    internal class ScopeGuard<T>(Func<T> init , Action<T> disposeAction) : IDisposable
+    {
+        private readonly Action<T> _disposeAction = disposeAction;
+        private T _value = init();
+
+        public void Dispose()
+        {
+            _disposeAction(_value);
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the YAML parsing library, including the addition of a `YamlContext` for contextual parsing, a new `YamlPathFieldAttribute` for path resolution, and extensive updates to support these features across the codebase. These changes improve flexibility and enable advanced use cases, such as resolving file paths relative to a YAML file or the current directory.

### New Features:
* **`YamlContext` Class**: Added a new `YamlContext` class to provide contextual information, such as `FilePath` and `WorkingDirectory`, during YAML parsing. (`src/YAYL/YamlContext.cs`)
* **`YamlPathFieldAttribute`**: Introduced a new attribute to resolve file paths to absolute paths during parsing. Supports path types like `RelativeToFile` and `RelativeToCurrentDirectory`. (`src/YAYL/attributes/YamlPathFieldAttribute.cs`)
* **`YamlFieldPostProcessingAttribute`**: Added an abstract base class for post-processing YAML fields, allowing custom field transformations. (`src/YAYL/attributes/YamlFieldPostProcessingAttribute.cs`)
* **`YamlFilePathType` Enum**: Added an enum to define path resolution strategies. (`src/YAYL/YamlPathType.cs`)

### Core Parser Updates:
* **Context Integration**: Updated all parsing methods to accept an optional `YamlContext` parameter, enabling context-aware parsing. (`src/YAYL/YamlParser.cs`) [[1]](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eL71-R75) [[2]](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eL178-R252) [[3]](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eL301-R345)
* **Post-Processing Logic**: Added a `PostProcess` method to handle field transformations based on attributes like `YamlPathFieldAttribute`. (`src/YAYL/YamlParser.cs`)

### Documentation:
* **Changelog Update**: Documented the addition of `YamlContext` and `YamlPathFieldAttribute` in the changelog for version 1.6.0. (`CHANGELOG.md`)