### PR TITLE
Adding collection support to the YamlPathField attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.6.1] - 2025-05-12
+- **YamlPathFieldAttribute**: Attribute now properly works with collections.
+
 ## [1.6.0] - 2025-05-11
 
 - **Adding YamlContext**: New configuration object that can be provided to parse operations.

--- a/src/YAYL/YamlParser.cs
+++ b/src/YAYL/YamlParser.cs
@@ -471,29 +471,13 @@ public class YamlParser(YamlNamingPolicy namingPolicy = YamlNamingPolicy.KebabCa
             return await ConvertToArrayAsync(node, targetType, context, cancellationToken).ConfigureAwait(false);
         }
 
-        if (GetGenericCollection(targetType) is Type genericType)
+        if (targetType.GetGenericCollection() is Type genericType)
         {
             return await ConvertToGenericCollectionAsync(node, genericType, targetType, context, cancellationToken).ConfigureAwait(false);
         }
 
         throw new YamlParseException($"Cannot convert sequence to type: {targetType.Name}");
     }
-
-    private static Type? GetGenericCollection(Type type) => type.IsGenericType switch
-    {
-        true => type.GetGenericTypeDefinition() switch
-        {
-            var t when t == typeof(List<>) => t,
-            var t when t == typeof(IList<>) => typeof(List<>),
-            var t when t == typeof(ICollection<>) => typeof(List<>),
-            var t when t == typeof(IEnumerable<>) => typeof(List<>),
-            var t when t == typeof(ISet<>) => typeof(HashSet<>),
-            var t when t == typeof(HashSet<>) => typeof(HashSet<>),
-            var t when t == typeof(SortedSet<>) => typeof(SortedSet<>),
-            _ => null
-        },
-        false => null,
-    };
 
     private static bool AddToGenericCollection<T>(ICollection<T> collection, T value)
     {

--- a/src/YAYL/attributes/YamlPathFieldAttribute.cs
+++ b/src/YAYL/attributes/YamlPathFieldAttribute.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
+using YAYL.Reflection;
 
 namespace YAYL.Attributes;
 
@@ -7,22 +10,13 @@ public class YamlPathFieldAttribute(YamlFilePathType pathType = YamlFilePathType
 {
     public readonly YamlFilePathType PathType = pathType;
 
-    internal override object? Process(object? value, Type fieldType, YamlContext? context)
+    private string ProcessStringField(string value, YamlContext? context)
     {
-        if (value == null)
-        {
-            return null;
-        }
-        if (value is not string stringValue)
-        {
-            throw new YamlParseException($"The PathFieldAttribute can only be applied to string fields. Found {fieldType.Name}.");
-        }
         switch (PathType)
         {
             case YamlFilePathType.RelativeToCurrentDirectory:
             {
-                return Path.GetFullPath(Path.Combine(context?.WorkingDirectory ?? Environment.CurrentDirectory, stringValue));
-
+                return Path.GetFullPath(Path.Combine(context?.WorkingDirectory ?? Environment.CurrentDirectory, value));
             }
             case YamlFilePathType.RelativeToFile:
             {
@@ -35,10 +29,34 @@ public class YamlPathFieldAttribute(YamlFilePathType pathType = YamlFilePathType
                 {
                     throw new YamlParseException($"The file path {context.FilePath} is invalid.");
                 }
-                return Path.GetFullPath(Path.Combine(fileDirectory, stringValue));
+                return Path.GetFullPath(Path.Combine(fileDirectory, value));
             }
             default:
                 throw new YamlParseException($"Unknown path type: {PathType}.");
         }
     }
+
+    private object ProcessStringEnumerable(IEnumerable<string> values, Type fieldType, YamlContext? context)
+    {
+        var genericCollection = fieldType.GetGenericCollection() ??
+            throw new YamlParseException($"The PathFieldAttribute can only be applied to string and string collection fields. Found {fieldType.Name}.");
+
+        var collectionType = genericCollection.MakeGenericType(typeof(string));
+        var collection = (ICollection<string>?) Activator.CreateInstance(collectionType) ??
+            throw new YamlParseException($"The PathFieldAttribute can only be applied to string and string collection fields. Found {fieldType.Name}.");
+        foreach (var value in values)
+        {
+            var processedValue = ProcessStringField(value, context);
+            collection.Add(processedValue);
+        }
+        return collection;
+    }
+
+    internal override object? Process(object? value, Type fieldType, YamlContext? context) => value switch
+    {
+        null => null,
+        string stringValue => ProcessStringField(stringValue, context),
+        IEnumerable<string> enumerable => ProcessStringEnumerable(enumerable, fieldType, context),
+        _ => throw new YamlParseException($"The PathFieldAttribute can only be applied to string and string collection fields. Found {fieldType.Name}.")
+    };
 }

--- a/src/YAYL/reflection/Extensions.cs
+++ b/src/YAYL/reflection/Extensions.cs
@@ -57,4 +57,20 @@ internal static class Extensions
         var attributeType = attribute.GetType();
         return attributeType.IsGenericType && attributeType.GetGenericTypeDefinition() == typeof(YamlDerivedTypeEnumAttribute<>);
     }
+
+    public static Type? GetGenericCollection(this Type type) => type.IsGenericType switch
+    {
+        true => type.GetGenericTypeDefinition() switch
+        {
+            var t when t == typeof(List<>) => t,
+            var t when t == typeof(IList<>) => typeof(List<>),
+            var t when t == typeof(ICollection<>) => typeof(List<>),
+            var t when t == typeof(IEnumerable<>) => typeof(List<>),
+            var t when t == typeof(ISet<>) => typeof(HashSet<>),
+            var t when t == typeof(HashSet<>) => typeof(HashSet<>),
+            var t when t == typeof(SortedSet<>) => typeof(SortedSet<>),
+            _ => null
+        },
+        false => null,
+    };
 }

--- a/test/YAYL.Tests/YamlParserTests.Files.cs
+++ b/test/YAYL.Tests/YamlParserTests.Files.cs
@@ -32,6 +32,11 @@ public partial class YamlParserTests: IDisposable
             string ContentFile
     );
 
+    internal record ObjectWithFilePropertyCollection(
+            [property: YamlPathField(YamlFilePathType.RelativeToFile)]
+            List<string> ContentFiles
+    );
+
 
     [Fact]
     public void Parse_FileProperty_RelativeToWorkingDirectory()
@@ -55,6 +60,18 @@ public partial class YamlParserTests: IDisposable
         var result = parser.Parse<ObjectWithFilePropertyFile>(yaml, new(){ FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
         Assert.NotNull(result);
         Assert.Equal(Path.Combine(_tempDirectory, "content.txt"), result.ContentFile);
+    }
+
+    [Fact]
+    public void Parse_FileProperty_RelativeToFile_Collection()
+    {
+        var yaml = @"content-files: [ ../content.txt, ../content2.txt ]";
+
+        var parser = new YamlParser();
+
+        var result = parser.Parse<ObjectWithFilePropertyCollection>(yaml, new(){ FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
+        Assert.NotNull(result);
+        Assert.Equal([Path.Combine(_tempDirectory, "content.txt"), Path.Combine(_tempDirectory, "content2.txt")], result.ContentFiles);
     }
 
     [Fact]
@@ -149,6 +166,19 @@ public partial class YamlParserTests: IDisposable
         Assert.NotNull(result);
         Assert.Equal("/content.txt", result.ContentFile);
     }
+
+    [Fact]
+    public void Parse_AbsolutePath_Collection()
+    {
+        var yaml = @"content-files: [ /content.txt, /content2.txt ]";
+
+        var parser = new YamlParser();
+
+        var result = parser.Parse<ObjectWithFilePropertyCollection>(yaml, new(){ FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
+        Assert.NotNull(result);
+        Assert.Equal(new List<string> { "/content.txt", "/content2.txt" }, result.ContentFiles);
+    }
+
 
     internal class TestFile: IDisposable
     {


### PR DESCRIPTION
This pull request introduces enhancements to the `YamlPathFieldAttribute` to support collections, refactors code for better reusability, and adds new test cases to ensure correctness. The most notable changes include the addition of collection support for `YamlPathFieldAttribute`, moving the `GetGenericCollection` method to a shared location, and adding unit tests for the new functionality.

### Enhancements to `YamlPathFieldAttribute`:
* Added support for processing collections of strings in `YamlPathFieldAttribute` by introducing the `ProcessStringEnumerable` method and updating the `Process` method to handle `IEnumerable<string>` types. [[1]](diffhunk://#diff-ff7a5046d785121441d869e0cd50b92b5d7cfe1870783800ed2fdc8ba81d3fc6R2-R19) [[2]](diffhunk://#diff-ff7a5046d785121441d869e0cd50b92b5d7cfe1870783800ed2fdc8ba81d3fc6L38-R61)

### Code refactoring:
* Moved the `GetGenericCollection` method from `YamlParser.cs` to a shared extension method in `Extensions.cs` to improve code reuse. [[1]](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eL474-L497) [[2]](diffhunk://#diff-bf10f703eab87a1aa8cf3a9a39509281ac162cebfb99f52ed5c85a6f2bbe6a35R60-R75)

### Testing improvements:
* Added new test cases to validate the functionality of `YamlPathFieldAttribute` with collections, including relative and absolute file paths. [[1]](diffhunk://#diff-8d93867ca4dc497aeeb8650467899609d0a5d2bc4a7090dfea866adef5f79cbfR35-R39) [[2]](diffhunk://#diff-8d93867ca4dc497aeeb8650467899609d0a5d2bc4a7090dfea866adef5f79cbfR65-R76) [[3]](diffhunk://#diff-8d93867ca4dc497aeeb8650467899609d0a5d2bc4a7090dfea866adef5f79cbfR170-R182)

### Documentation update:
* Updated `CHANGELOG.md` to reflect the new functionality added in version 1.6.1.