### PR TITLE
Adding YamlVariantAttribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.7.0] - Unreleased
+## [1.7.0] - 2025-07-04
 
 - **YamlExtraAttribute:** Adding attribute that allows storing unhandled fields to be stored in a `Dictionary<string, object>`.
 - **YamlVariantAttribute:** Adding attribute to allow parsing `object` based variants, this also includes the `YamlVariantTypeObjectAttribute` and `YamlVariantTypeScalarAttribute`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.7.0] - Unreleased
 
 - **YamlExtraAttribute:** Adding attribute that allows storing unhandled fields to be stored in a `Dictionary<string, object>`.
+- **YamlVariantAttribute:** Adding attribute to allow parsing `object` based variants, this also includes the `YamlVariantTypeObjectAttribute` and `YamlVariantTypeScalarAttribute`.
 
 ## [1.6.1] - 2025-05-12
 - **YamlPathFieldAttribute**: Attribute now properly works with collections.

--- a/src/YAYL/attributes/YamlVariantAttribute.cs
+++ b/src/YAYL/attributes/YamlVariantAttribute.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace YAYL.Attributes;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public class YamlVariantAttribute : Attribute
+{
+}

--- a/src/YAYL/attributes/YamlVariantTypeObjectAttribute.cs
+++ b/src/YAYL/attributes/YamlVariantTypeObjectAttribute.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace YAYL.Attributes;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true)]
+public class YamlVariantTypeObjectAttribute(Type type, string fieldToTest) : Attribute
+{
+    public Type Type { get; } = type;
+    public string FieldToTest { get; } = fieldToTest;
+
+    public void Deconstruct(out Type type, out string fieldToTest)
+    {
+        type = Type;
+        fieldToTest = FieldToTest;
+    }
+}

--- a/src/YAYL/attributes/YamlVariantTypeScalarAttribute.cs
+++ b/src/YAYL/attributes/YamlVariantTypeScalarAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace YAYL.Attributes;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true)]
+public class YamlVariantTypeScalarAttribute(Type type) : Attribute
+{
+    public Type Type { get; } = type;
+}

--- a/test/YAYL.Tests/YamlVariantAttributeTests.cs
+++ b/test/YAYL.Tests/YamlVariantAttributeTests.cs
@@ -1,0 +1,145 @@
+using YAYL.Attributes;
+
+namespace YAYL.Tests;
+
+public class YamlVariantAttributeTests
+{
+    public record Bar(string Baz);
+    public record Other(string Field);
+
+    public record FooWithProperties
+    {
+        [YamlVariant]
+        [YamlVariantTypeScalar(typeof(string))]
+        [YamlVariantTypeScalar(typeof(int))]
+        [YamlVariantTypeObject(typeof(Bar), "baz")]
+        [YamlVariantTypeObject(typeof(Other), "field")]
+        public object? Value { get; set; }
+    }
+
+    public record FooWithConstructor(
+        [property: YamlVariant]
+        [property: YamlVariantTypeScalar(typeof(string))]
+        [property: YamlVariantTypeScalar(typeof(int))]
+        [property: YamlVariantTypeObject(typeof(Bar), "baz")]
+        [property: YamlVariantTypeObject(typeof(Other), "field")]
+        object? Value
+    );
+
+    [Fact]
+    public void Parse_WithStringVariant_ParsesAsString()
+    {
+        var yaml = "value: hello world";
+
+        var parser = new YamlParser();
+        var result = parser.Parse<FooWithProperties>(yaml);
+
+        Assert.NotNull(result);
+        Assert.IsType<string>(result.Value);
+        Assert.Equal("hello world", result.Value);
+    }
+
+    [Fact]
+    public void Parse_WithIntVariant_ParsesAsInt()
+    {
+        var yaml = "value: 42";
+
+        var parser = new YamlParser();
+        var result = parser.Parse<FooWithProperties>(yaml);
+
+        Assert.NotNull(result);
+        Assert.IsType<int>(result.Value);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void Parse_WithBarObjectVariant_ParsesAsBar()
+    {
+        var yaml = "value:\n  baz: test value";
+
+        var parser = new YamlParser();
+        var result = parser.Parse<FooWithProperties>(yaml);
+
+        Assert.NotNull(result);
+        Assert.IsType<Bar>(result.Value);
+        var bar = (Bar)result.Value!;
+        Assert.Equal("test value", bar.Baz);
+    }
+
+    [Fact]
+    public void Parse_WithOtherObjectVariant_ParsesAsOther()
+    {
+        var yaml = "value:\n  field: another value";
+
+        var parser = new YamlParser();
+        var result = parser.Parse<FooWithProperties>(yaml);
+
+        Assert.NotNull(result);
+        Assert.IsType<Other>(result.Value);
+        var other = (Other)result.Value!;
+        Assert.Equal("another value", other.Field);
+    }
+
+    [Fact]
+    public void Parse_WithConstructorParameter_StringVariant_ParsesAsString()
+    {
+        var yaml = "value: hello constructor";
+
+        var parser = new YamlParser();
+        var result = parser.Parse<FooWithConstructor>(yaml);
+
+        Assert.NotNull(result);
+        Assert.IsType<string>(result.Value);
+        Assert.Equal("hello constructor", result.Value);
+    }
+
+    [Fact]
+    public void Parse_WithConstructorParameter_ObjectVariant_ParsesAsBar()
+    {
+        var yaml = "value:\n  baz: constructor bar";
+
+        var parser = new YamlParser();
+        var result = parser.Parse<FooWithConstructor>(yaml);
+
+        Assert.NotNull(result);
+        Assert.IsType<Bar>(result.Value);
+        var bar = (Bar)result.Value!;
+        Assert.Equal("constructor bar", bar.Baz);
+    }
+
+    public class InvalidVariantProperty
+    {
+        [YamlVariantTypeScalar(typeof(string))]
+        public object? Value { get; set; }
+    }
+
+    public class InvalidScalarType
+    {
+        [YamlVariant]
+        [YamlVariantTypeScalar(typeof(int))]
+        public object? Value { get; set; }
+    }
+
+    [Fact]
+    public void Parse_InvalidScalarType_ThrowsException()
+    {
+        var yaml = "value: test";
+
+        var parser = new YamlParser();
+
+        var exception = Assert.Throws<YamlParseException>(() => parser.Parse<InvalidScalarType>(yaml));
+        Assert.Contains("Cannot convert scalar value 'test' to any of the allowed types:", exception.Message);
+    }
+
+    [Fact]
+    public void Parse_UnmatchedObjectField_ThrowsException()
+    {
+        var yaml = "value:\n" +
+                   "  unknown: value";
+
+        var parser = new YamlParser();
+
+        var exception = Assert.Throws<YamlParseException>(() => parser.Parse<FooWithProperties>(yaml));
+        Assert.Contains("Mapping node for property 'Value' does not contain any of the known variant types.", exception.Message);
+    }
+}

--- a/test/YAYL.Tests/YamlVariantCollectionTests.cs
+++ b/test/YAYL.Tests/YamlVariantCollectionTests.cs
@@ -1,0 +1,171 @@
+using YAYL.Attributes;
+
+namespace YAYL.Tests;
+
+public class YamlVariantCollectionTests
+{
+    public record Bar(string Baz);
+    public record Other(string Field);
+
+    public record FooWithArrayVariant
+    {
+        [YamlVariant]
+        [YamlVariantTypeScalar(typeof(string))]
+        [YamlVariantTypeScalar(typeof(int))]
+        [YamlVariantTypeObject(typeof(Bar), "baz")]
+        [YamlVariantTypeObject(typeof(Other), "field")]
+        public object[]? Values { get; set; }
+    };
+
+    public record FooWithListVariant
+    {
+        [YamlVariant]
+        [YamlVariantTypeScalar(typeof(string))]
+        [YamlVariantTypeScalar(typeof(int))]
+        [YamlVariantTypeObject(typeof(Bar), "baz")]
+        [YamlVariantTypeObject(typeof(Other), "field")]
+        public List<object>? Values { get; set; }
+    }
+
+    public record FooWithDictVariant
+    {
+        [YamlVariant]
+        [YamlVariantTypeScalar(typeof(string))]
+        [YamlVariantTypeScalar(typeof(int))]
+        [YamlVariantTypeObject(typeof(Bar), "baz")]
+        [YamlVariantTypeObject(typeof(Other), "field")]
+        public Dictionary<string, object>? Values { get; set; }
+    }
+
+    [Fact]
+    public void Parse_WithArrayOfMixedVariants_ParsesCorrectly()
+    {
+        var yaml = "values:\n" +
+                   "- hello\n" +
+                   "- 42\n" +
+                   "- baz: test value\n" +
+                   "- field: another value\n";
+
+        var parser = new YamlParser();
+        var result = parser.Parse<FooWithArrayVariant>(yaml);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Values);
+        Assert.Equal(4, result.Values.Length);
+
+        Assert.IsType<string>(result.Values[0]);
+        Assert.Equal("hello", result.Values[0]);
+
+        Assert.IsType<int>(result.Values[1]);
+        Assert.Equal(42, result.Values[1]);
+
+        Assert.IsType<Bar>(result.Values[2]);
+        var bar = (Bar)result.Values[2];
+        Assert.Equal("test value", bar.Baz);
+
+        Assert.IsType<Other>(result.Values[3]);
+        var other = (Other)result.Values[3];
+        Assert.Equal("another value", other.Field);
+    }
+
+    [Fact]
+    public void Parse_WithListOfMixedVariants_ParsesCorrectly()
+    {
+        var yaml = "values:\n" +
+                   "  - hello\n" +
+                   "  - 42\n" +
+                   "  - baz: test value\n" +
+                   "  - field: another value";
+
+        var parser = new YamlParser();
+        var result = parser.Parse<FooWithListVariant>(yaml);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Values);
+        Assert.Equal(4, result.Values.Count);
+
+        Assert.IsType<string>(result.Values[0]);
+        Assert.Equal("hello", result.Values[0]);
+
+        Assert.IsType<int>(result.Values[1]);
+        Assert.Equal(42, result.Values[1]);
+
+        Assert.IsType<Bar>(result.Values[2]);
+        var bar = (Bar)result.Values[2];
+        Assert.Equal("test value", bar.Baz);
+
+        Assert.IsType<Other>(result.Values[3]);
+        var other = (Other)result.Values[3];
+        Assert.Equal("another value", other.Field);
+    }
+
+    [Fact]
+    public void Parse_WithDictionaryOfMixedVariants_ParsesCorrectly()
+    {
+        var yaml = "values:\n" +
+                   "  str-key: hello\n" +
+                   "  int-key: 42\n" +
+                   "  bar-key:\n" +
+                   "    baz: test value\n" +
+                   "  other-key:\n" +
+                   "    field: another value";
+
+        var parser = new YamlParser();
+        var result = parser.Parse<FooWithDictVariant>(yaml);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Values);
+        Assert.Equal(4, result.Values.Count);
+
+        Assert.IsType<string>(result.Values["str-key"]);
+        Assert.Equal("hello", result.Values["str-key"]);
+
+        Assert.IsType<int>(result.Values["int-key"]);
+        Assert.Equal(42, result.Values["int-key"]);
+
+        Assert.IsType<Bar>(result.Values["bar-key"]);
+        var bar = (Bar)result.Values["bar-key"];
+        Assert.Equal("test value", bar.Baz);
+
+        Assert.IsType<Other>(result.Values["other-key"]);
+        var other = (Other)result.Values["other-key"];
+        Assert.Equal("another value", other.Field);
+    }
+
+    public class InvalidListVariant
+    {
+        [YamlVariant]
+        [YamlVariantTypeScalar(typeof(string))]
+        public List<string>? Values { get; set; }
+    }
+
+    [Fact]
+    public void Parse_InvalidListVariantType_ThrowsException()
+    {
+        var yaml = "values: [test]";
+
+        var parser = new YamlParser();
+
+        var exception = Assert.Throws<YamlParseException>(() => parser.Parse<InvalidListVariant>(yaml));
+        Assert.Contains("must be 'object'", exception.Message);
+    }
+
+    public class InvalidDictVariant
+    {
+        [YamlVariant]
+        [YamlVariantTypeScalar(typeof(string))]
+        public Dictionary<string, string>? Values { get; set; }
+    }
+
+    [Fact]
+    public void Parse_InvalidDictVariantType_ThrowsException()
+    {
+        var yaml = "values:\n" +
+                   "  test: value";
+
+        var parser = new YamlParser();
+
+        var exception = Assert.Throws<YamlParseException>(() => parser.Parse<InvalidDictVariant>(yaml));
+        Assert.Contains("the value type must be 'object'", exception.Message);
+    }
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the `YAYL` library, enabling support for parsing YAML object variants. The changes include the addition of new attributes for defining variant types, updates to the `YamlParser` class to handle these variants, and comprehensive tests to validate functionality. Below is a summary of the most important changes grouped by theme.

### Enhancements to YAML Parsing:
* Added support for parsing object variants using the new `YamlVariantAttribute`, `YamlVariantTypeObjectAttribute`, and `YamlVariantTypeScalarAttribute`. These attributes enable properties to handle scalar, mapping, and sequence variants in YAML. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR6) `YamlVariantAttribute.cs` [[2]](diffhunk://#diff-def70659f5660727e0233cd9cce3a5f9232e806ca37515172a0bd4920fccd85bR1-R8) `YamlVariantTypeObjectAttribute.cs` [[3]](diffhunk://#diff-b993faf7d331a323489328148583176ea21a59995301289cb30ec074a7ac3e1fR1-R16) `YamlVariantTypeScalarAttribute.cs` [[4]](diffhunk://#diff-3fe2817d9ff69fdfe781879b3fdff89201baaac2686851acdf680b49f9c82459R1-R9)
* Updated `YamlParser` with methods to process scalar, mapping, and sequence nodes for variant properties, including validation of allowed types and handling of mismatched variants. (`YamlParser.cs` [[1]](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eR131-R235) [[2]](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eR260-R264) [[3]](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eL367-R527) [[4]](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eL437-R592) [[5]](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eL451-R643)

### Code Improvements:
* Introduced `PropertyProxy` to adapt `PropertyInfo` for variant handling, simplifying type manipulation during parsing. (`YamlParser.cs` [src/YAYL/YamlParser.csR17-R60](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eR17-R60))

### Testing and Validation:
* Added `YamlVariantAttributeTests` with extensive test cases to verify parsing of scalar and object variants, constructor-based parsing, and error handling for invalid or unmatched variants. (`YamlVariantAttributeTests.cs` [test/YAYL.Tests/YamlVariantAttributeTests.csR1-R145](diffhunk://#diff-a519dc5e80b7fb8c51b4d7e8e6b4b494366908fa4b42a8a85e449a6b74a47cf0R1-R145))

These changes collectively enhance the flexibility and robustness of the `YAYL` library, allowing for more complex YAML parsing scenarios while ensuring backward compatibility and reliability.