### PR TITLE
Retargeting library to net8.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,9 @@
 	"name": "Ubuntu",
 	"image": "mcr.microsoft.com/devcontainers/base:noble",
 	"features": {
-		"ghcr.io/devcontainers/features/dotnet:2": {}
+		"ghcr.io/devcontainers/features/dotnet:2": {
+			"dotnetRuntimeVersions": ["8.0"]
+		}
 	},
 	"customizations": {
 		"vscode": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.7.1] - 2025-07-07
+
+- **Updated library to target .net 8:** Updated to point to latest LTS version.
+
 ## [1.7.0] - 2025-07-04
 
 - **YamlExtraAttribute:** Adding attribute that allows storing unhandled fields to be stored in a `Dictionary<string, object>`.

--- a/src/YAYL/YAYL.csproj
+++ b/src/YAYL/YAYL.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>false</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/YAYL.Tests/YAYL.Tests.csproj
+++ b/test/YAYL.Tests/YAYL.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
This pull request updates the project to target .NET 8, aligning with the latest Long-Term Support (LTS) version. Changes include updates to the dev container configuration, project files, and documentation.

### Updates to target .NET 8:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L5-R7): Modified the `dotnet` feature to specify `dotnetRuntimeVersions` as `["8.0"]`.
* [`src/YAYL/YAYL.csproj`](diffhunk://#diff-b7b120078363510e3b2ed02f817cc7b9e839e046fdbdc081f807c4f7a2044eaaL19-R19): Changed the `TargetFramework` from `net9.0` to `net8.0`.
* [`test/YAYL.Tests/YAYL.Tests.csproj`](diffhunk://#diff-3c231975374a90db19ef30655935092025688089c1b5d9463ba6b2bb997bf62dL4-R4): Updated the `TargetFramework` from `net9.0` to `net8.0`.

### Documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R6): Added an entry for version `1.7.1`, noting the update to target .NET 8.