### PR TITLE
Fixed issue that was causing some mapped fields to show up in the field marked with [YamlExtra].

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.7.2] - 2025-07-08
+
+- **Fixed**: Fixed issue that was causing some mapped fields to show up in the field marked with `[YamlExtra]`.
+
 ## [1.7.1] - 2025-07-07
 
 - **Updated library to target .net 8:** Updated to point to latest LTS version.

--- a/src/YAYL/YamlParser.cs
+++ b/src/YAYL/YamlParser.cs
@@ -252,15 +252,18 @@ public class YamlParser(YamlNamingPolicy namingPolicy = YamlNamingPolicy.KebabCa
             if (Attribute.IsDefined(property, typeof(YamlIgnoreAttribute)))
             {
                 propertyValues[property.Name] = (property, null);
+                processedYamlProperties.Add(yamlPropertyName);
             }
             else if (Attribute.IsDefined(property, typeof(YamlExtraAttribute)))
             {
                 propertyValues[property.Name] = (property, extraValues);
+                processedYamlProperties.Add(yamlPropertyName);
             }
             else if (Attribute.IsDefined(property, typeof(YamlVariantAttribute)))
             {
                 var value = await GetVariantPropertyValueAsync(property, propertyNode.Value, context, cancellationToken).ConfigureAwait(false);
                 propertyValues[property.Name] = (property, value);
+                processedYamlProperties.Add(yamlPropertyName);
             }
             else if (propertyNode.Value != null)
             {
@@ -272,6 +275,7 @@ public class YamlParser(YamlNamingPolicy namingPolicy = YamlNamingPolicy.KebabCa
             else if ((Nullable.GetUnderlyingType(property.PropertyType) != null) || property.IsNullableReferenceType())
             {
                 propertyValues[property.Name] = (property, null);
+                processedYamlProperties.Add(yamlPropertyName);
             }
             else
             {


### PR DESCRIPTION
This pull request introduces several changes to improve the functionality and robustness of the YAML parser, enhance test coverage, and fix a bug related to extra properties in mapped fields. The most notable updates include adding support for polymorphic variants, ensuring processed YAML properties are tracked correctly, and fixing a bug where certain fields incorrectly appeared in extra properties.

### Bug Fixes:
* **Fixed issue with `[YamlExtra]` fields**: Resolved a bug where some mapped fields were incorrectly marked as extra properties in the YAML parser. (`CHANGELOG.md`)

### Parser Enhancements:
* **Tracked processed YAML properties**: Added logic in `YamlParser` to track processed YAML properties for fields marked with `[YamlIgnore]`, `[YamlExtra]`, `[YamlVariant]`, and nullable types. (`src/YAYL/YamlParser.cs`) [[1]](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eR255-R266) [[2]](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eR278)

### Test Coverage Improvements:
* **Added polymorphic variant tests**: Introduced new test cases to validate parsing of polymorphic variants, scalar variants, and object variants, as well as ensuring variant fields do not appear in extra properties. (`test/YAYL.Tests/YamlVariantAttributeTests.cs`)
* **Refactored test YAML string formatting**: Updated test cases to use cleaner multi-line string formatting for YAML data. (`test/YAYL.Tests/YamlVariantAttributeTests.cs`)