### PR TITLE
Fixed issue that was causing the discriminator field in discriminated unions to show in the field marked with YamlExtra.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.7.3] - 2025-07-08
+
+- **Fixed**: Fixed issue that was causing the discriminator field in discriminated unions to show in the field marked with `[YamlExtra]`.
+
 ## [1.7.2] - 2025-07-08
 
 - **Fixed**: Fixed issue that was causing some mapped fields to show up in the field marked with `[YamlExtra]`.

--- a/src/YAYL/YamlParser.cs
+++ b/src/YAYL/YamlParser.cs
@@ -243,6 +243,12 @@ public class YamlParser(YamlNamingPolicy namingPolicy = YamlNamingPolicy.KebabCa
         HashSet<string> processedYamlProperties = [];
         Dictionary<string, object> extraValues = [];
 
+        /* If the type is polymorphic, add the discriminator property to the processed list, as it can be implicit */
+        if (type.GetCustomAttribute<YamlPolymorphicAttribute>() is { TypeDiscriminatorPropertyName: string discriminatorPropertyName })
+        {
+            processedYamlProperties.Add(discriminatorPropertyName);
+        }
+
         foreach (var property in properties)
         {
             var yamlPropertyName = _namingPolicy.GetPropertyName(property);


### PR DESCRIPTION
This pull request introduces a fix for handling the discriminator field in polymorphic types when using the `[YamlExtra]` attribute. The changes include updates to the changelog, modifications to the `YamlParser` logic, and the addition of a new test case to validate the fix.

### Fix for discriminator field handling in polymorphic types:

* **Changelog update**: Documented the fix for the issue where the discriminator field in discriminated unions was incorrectly showing up in the field marked with `[YamlExtra]`. (`CHANGELOG.md`)
* **Parser logic update**: Modified the `AddVariableResolver` method in `YamlParser` to automatically add the discriminator property to the processed list if the type is polymorphic. (`src/YAYL/YamlParser.cs`)

### New test case for validation:

* **Test addition**: Added a new test case, `Parse_Polymorphic_DiscriminatorNotPresent`, to ensure that the discriminator field is correctly handled and does not appear in the `Extra` dictionary for polymorphic types. This includes new test records (`Shape`, `Circle`, and `Rectangle`) to simulate polymorphic behavior. (`test/YAYL.Tests/YamlExtraAttributeTests.cs`)