### PR TITLE
Refactoring parser code.

### DIFF
--- a/src/YAYL/YamlContext.cs
+++ b/src/YAYL/YamlContext.cs
@@ -2,6 +2,6 @@ namespace YAYL;
 
 public class YamlContext
 {
-    public string? FilePath {get; init;}
-    public string? WorkingDirectory {get; init;}
+    public string? FilePath { get; init; }
+    public string? WorkingDirectory { get; init; }
 }

--- a/src/YAYL/YamlSerializer.cs
+++ b/src/YAYL/YamlSerializer.cs
@@ -182,7 +182,7 @@ public class YamlSerializer(YamlNamingPolicy namingPolicy = YamlNamingPolicy.Keb
     {
         var mappingNode = new YamlMappingNode();
         string? discriminatorPropertyName = null;
-        if (type.GetCustomAttribute<YamlPolymorphicAttribute>() is YamlPolymorphicAttribute( string discriminatorProperty ))
+        if (type.GetCustomAttribute<YamlPolymorphicAttribute>() is YamlPolymorphicAttribute(string discriminatorProperty))
         {
             if (type.GetDerivedTypeAttribute() is YamlDerivedTypeAttribute derivedTypeAttribute)
             {
@@ -213,7 +213,7 @@ public class YamlSerializer(YamlNamingPolicy namingPolicy = YamlNamingPolicy.Keb
             }
             if (Nullable.GetUnderlyingType(property.PropertyType) is Type underlyingType)
             {
-                var hasValue = (bool) property.PropertyType.GetProperty("HasValue")?.GetValue(value)!;
+                var hasValue = (bool)property.PropertyType.GetProperty("HasValue")?.GetValue(value)!;
                 if (hasValue)
                 {
                     var valueProperty = property.PropertyType.GetProperty("Value");

--- a/src/YAYL/attributes/YamlPathFieldAttribute.cs
+++ b/src/YAYL/attributes/YamlPathFieldAttribute.cs
@@ -15,22 +15,22 @@ public class YamlPathFieldAttribute(YamlFilePathType pathType = YamlFilePathType
         switch (PathType)
         {
             case YamlFilePathType.RelativeToCurrentDirectory:
-            {
-                return Path.GetFullPath(Path.Combine(context?.WorkingDirectory ?? Environment.CurrentDirectory, value));
-            }
+                {
+                    return Path.GetFullPath(Path.Combine(context?.WorkingDirectory ?? Environment.CurrentDirectory, value));
+                }
             case YamlFilePathType.RelativeToFile:
-            {
-                if (context?.FilePath == null)
                 {
-                    throw new YamlParseException($"The RelativeToFile path type can not be used when FilePath is not set in the context.");
+                    if (context?.FilePath == null)
+                    {
+                        throw new YamlParseException($"The RelativeToFile path type can not be used when FilePath is not set in the context.");
+                    }
+                    var fileDirectory = Path.GetDirectoryName(context.FilePath);
+                    if (string.IsNullOrWhiteSpace(fileDirectory))
+                    {
+                        throw new YamlParseException($"The file path {context.FilePath} is invalid.");
+                    }
+                    return Path.GetFullPath(Path.Combine(fileDirectory, value));
                 }
-                var fileDirectory = Path.GetDirectoryName(context.FilePath);
-                if (string.IsNullOrWhiteSpace(fileDirectory))
-                {
-                    throw new YamlParseException($"The file path {context.FilePath} is invalid.");
-                }
-                return Path.GetFullPath(Path.Combine(fileDirectory, value));
-            }
             default:
                 throw new YamlParseException($"Unknown path type: {PathType}.");
         }
@@ -42,7 +42,7 @@ public class YamlPathFieldAttribute(YamlFilePathType pathType = YamlFilePathType
             throw new YamlParseException($"The PathFieldAttribute can only be applied to string and string collection fields. Found {fieldType.Name}.");
 
         var collectionType = genericCollection.MakeGenericType(typeof(string));
-        var collection = (ICollection<string>?) Activator.CreateInstance(collectionType) ??
+        var collection = (ICollection<string>?)Activator.CreateInstance(collectionType) ??
             throw new YamlParseException($"The PathFieldAttribute can only be applied to string and string collection fields. Found {fieldType.Name}.");
         foreach (var value in values)
         {

--- a/src/YAYL/conversion/EnumConverter.cs
+++ b/src/YAYL/conversion/EnumConverter.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace YAYL.Conversion;
+
+internal class EnumConverter : TypeConverter<Enum>
+{
+    public EnumConverter() : base((s, t) => (Enum)Enum.Parse(t, NormalizeEnumValueName(s), true))
+    {
+    }
+    public override bool CanConvert(Type targetType) => targetType.IsEnum;
+
+    private static string NormalizeEnumValueName(string value) =>
+        value.Replace("-", "").Replace("_", "").ToLowerInvariant();
+}

--- a/src/YAYL/conversion/ITypeConverter.cs
+++ b/src/YAYL/conversion/ITypeConverter.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using YamlDotNet.RepresentationModel;
+
+namespace YAYL.Conversion;
+
+public interface ITypeConverter
+{
+    Type TargetType { get; }
+
+    bool CanConvert(Type targetType);
+
+    object? Convert(string value, Type targetType, YamlNode node, CancellationToken cancellationToken);
+}

--- a/src/YAYL/conversion/TypeConverter.cs
+++ b/src/YAYL/conversion/TypeConverter.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading;
+using YamlDotNet.RepresentationModel;
+
+namespace YAYL.Conversion;
+
+public class TypeConverter<T>(Func<string, Type, T> converter) : ITypeConverter
+{
+    public Type TargetType => typeof(T);
+
+    public virtual bool CanConvert(Type targetType) => targetType == TargetType;
+
+    private readonly Func<string, Type, T> _converter = converter;
+
+    public object? Convert(string value, Type targetType, YamlNode node, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return _converter(value, targetType);
+        }
+        catch (Exception ex)
+        {
+            throw new YamlParseException($"Failed to convert '{value}' to type {targetType.Name} ({node.Start.Line}:{node.Start.Column})", node, ex);
+        }
+    }
+
+}

--- a/src/YAYL/conversion/TypeConverterFactory.cs
+++ b/src/YAYL/conversion/TypeConverterFactory.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading;
+using YamlDotNet.RepresentationModel;
+
+namespace YAYL.Conversion;
+
+internal class TypeConverterFactory
+{
+    private readonly List<ITypeConverter> _converters =
+    [
+        new TypeConverter<string>((s, _) => s),
+        new TypeConverter<bool>((s, _) => bool.Parse(s)),
+        new TypeConverter<int>((s, _) => int.Parse(s)),
+        new TypeConverter<long>((s, _) => long.Parse(s)),
+        new TypeConverter<double>((s, _) => double.Parse(s)),
+        new TypeConverter<float>((s, _) => float.Parse(s)),
+        new TypeConverter<decimal>((s, _) => decimal.Parse(s)),
+        new TypeConverter<Guid>((s, _) => Guid.Parse(s)),
+        new TypeConverter<DateTime>((s, _) => DateTime.Parse(s)),
+        new TypeConverter<DateTimeOffset>((s, _) => DateTimeOffset.Parse(s)),
+        new TypeConverter<TimeSpan>((s, _) => TimeSpan.Parse(s)),
+        new EnumConverter(),
+    ];
+
+    public object? Convert(string value, Type targetType, YamlNode node, CancellationToken cancellationToken)
+    {
+        Type actualTargetType = targetType;
+        if (Nullable.GetUnderlyingType(targetType) is Type underlyingType)
+        {
+            actualTargetType = underlyingType;
+        }
+
+        var converter = _converters.FirstOrDefault(c => c.CanConvert(actualTargetType));
+        if (converter != null)
+        {
+            return converter.Convert(value, actualTargetType, node, cancellationToken);
+        }
+
+        if (TypeDescriptor.GetConverter(actualTargetType).CanConvertFrom(typeof(string)))
+        {
+            try
+            {
+                return TypeDescriptor.GetConverter(actualTargetType).ConvertFrom(value);
+            }
+            catch (Exception ex)
+            {
+                throw new YamlParseException($"Failed to convert '{value}' to type {targetType.Name} ({node.Start.Line}:{node.Start.Column})", node, ex);
+            }
+        }
+
+        throw new YamlParseException($"Unsupported scalar type: {targetType.Name}", node);
+    }
+
+    public object? ConvertWithTypeInferenceAsync(string value, HashSet<Type>? allowedTypes, YamlNode node, CancellationToken cancellationToken)
+    {
+        Type[] typesToTry =
+        [
+            typeof(bool),
+            typeof(int),
+            typeof(long),
+            typeof(double),
+            typeof(DateTimeOffset),
+            typeof(Guid),
+            typeof(string),
+        ];
+
+        foreach (var type in typesToTry)
+        {
+            if (allowedTypes?.Contains(type) ?? true)
+            {
+                var converter = _converters.FirstOrDefault(c => c.CanConvert(type));
+                if (converter is not null)
+                {
+                    try
+                    {
+                        return converter.Convert(value, type, node, cancellationToken);
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+                }
+            }
+        }
+        throw new YamlParseException($"Cannot convert scalar value '{value}' to any of the allowed types: {string.Join(", ", allowedTypes?.Select(t => t.Name) ?? [])}", node);
+    }
+}

--- a/src/YAYL/util/YAMLExtensions.cs
+++ b/src/YAYL/util/YAMLExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using YamlDotNet.RepresentationModel;
 
 namespace YAYL.Util;
@@ -7,5 +8,16 @@ internal static class YAMLExtensions
     public static string Location(this YamlNode node)
     {
         return $"{node.Start.Line}:{node.Start.Column}";
+    }
+
+    private static readonly string[] ValidNullValues = ["~", "null", "NULL", "Null", "", " "];
+
+    public static string? GetValue(this YamlScalarNode node)
+    {
+        if (node.Value is not null)
+        {
+            return Array.Exists(ValidNullValues, v => v == node.Value) ? null : node.Value;
+        }
+        return node.Value;
     }
 }

--- a/test/YAYL.Tests/YamlParserTests.Files.cs
+++ b/test/YAYL.Tests/YamlParserTests.Files.cs
@@ -2,7 +2,7 @@ using YAYL.Attributes;
 
 namespace YAYL.Tests;
 
-public partial class YamlParserTests: IDisposable
+public partial class YamlParserTests : IDisposable
 {
     private string _tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
@@ -45,7 +45,7 @@ public partial class YamlParserTests: IDisposable
 
         var parser = new YamlParser();
 
-        var result = parser.Parse<ObjectWithFilePropertyCurrentDirectory>(yaml, new(){ WorkingDirectory = _tempDirectory });
+        var result = parser.Parse<ObjectWithFilePropertyCurrentDirectory>(yaml, new() { WorkingDirectory = _tempDirectory });
         Assert.NotNull(result);
         Assert.Equal(Path.Combine(_tempDirectory, "content.txt"), result.ContentFile);
     }
@@ -57,7 +57,7 @@ public partial class YamlParserTests: IDisposable
 
         var parser = new YamlParser();
 
-        var result = parser.Parse<ObjectWithFilePropertyFile>(yaml, new(){ FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
+        var result = parser.Parse<ObjectWithFilePropertyFile>(yaml, new() { FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
         Assert.NotNull(result);
         Assert.Equal(Path.Combine(_tempDirectory, "content.txt"), result.ContentFile);
     }
@@ -69,7 +69,7 @@ public partial class YamlParserTests: IDisposable
 
         var parser = new YamlParser();
 
-        var result = parser.Parse<ObjectWithFilePropertyCollection>(yaml, new(){ FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
+        var result = parser.Parse<ObjectWithFilePropertyCollection>(yaml, new() { FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
         Assert.NotNull(result);
         Assert.Equal([Path.Combine(_tempDirectory, "content.txt"), Path.Combine(_tempDirectory, "content2.txt")], result.ContentFiles);
     }
@@ -97,7 +97,7 @@ public partial class YamlParserTests: IDisposable
 
         var parser = new YamlParser();
         var result = parser.ParseFile<ObjectWithFilePropertyFile>(yamlFile.FilePath,
-         new(){ FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
+         new() { FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
 
         Assert.NotNull(result);
         Assert.Equal(Path.Combine(_tempDirectory, "content.txt"), result.ContentFile);
@@ -112,11 +112,13 @@ public partial class YamlParserTests: IDisposable
 
         var parser = new YamlParser();
 
-        using ScopeGuard<string> _e = new(() => {
+        using ScopeGuard<string> _e = new(() =>
+        {
             var oldWorkingDirectory = Environment.CurrentDirectory;
             Environment.CurrentDirectory = _tempDirectory;
             return oldWorkingDirectory;
-        }, oldWorkingDirectory => {
+        }, oldWorkingDirectory =>
+        {
             Environment.CurrentDirectory = oldWorkingDirectory;
         });
 
@@ -137,7 +139,7 @@ public partial class YamlParserTests: IDisposable
         var parser = new YamlParser();
 
         var result = parser.ParseFile<ObjectWithFilePropertyCurrentDirectory>(yamlFile.FilePath,
-            new(){ WorkingDirectory = Path.Combine(_tempDirectory, "other") });
+            new() { WorkingDirectory = Path.Combine(_tempDirectory, "other") });
 
         Assert.NotNull(result);
         Assert.Equal(Path.Combine(_tempDirectory, "other", "subdir", "content.txt"), result.ContentFile);
@@ -150,7 +152,7 @@ public partial class YamlParserTests: IDisposable
 
         var parser = new YamlParser();
 
-        var result = parser.Parse<ObjectWithFilePropertyCurrentDirectory>(yaml, new(){ WorkingDirectory = _tempDirectory });
+        var result = parser.Parse<ObjectWithFilePropertyCurrentDirectory>(yaml, new() { WorkingDirectory = _tempDirectory });
         Assert.NotNull(result);
         Assert.Equal("/content.txt", result.ContentFile);
     }
@@ -162,7 +164,7 @@ public partial class YamlParserTests: IDisposable
 
         var parser = new YamlParser();
 
-        var result = parser.Parse<ObjectWithFilePropertyFile>(yaml, new(){ FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
+        var result = parser.Parse<ObjectWithFilePropertyFile>(yaml, new() { FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
         Assert.NotNull(result);
         Assert.Equal("/content.txt", result.ContentFile);
     }
@@ -174,13 +176,13 @@ public partial class YamlParserTests: IDisposable
 
         var parser = new YamlParser();
 
-        var result = parser.Parse<ObjectWithFilePropertyCollection>(yaml, new(){ FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
+        var result = parser.Parse<ObjectWithFilePropertyCollection>(yaml, new() { FilePath = Path.Combine(_tempDirectory, "subdir", "test.yaml") });
         Assert.NotNull(result);
         Assert.Equal(new List<string> { "/content.txt", "/content2.txt" }, result.ContentFiles);
     }
 
 
-    internal class TestFile: IDisposable
+    internal class TestFile : IDisposable
     {
         public readonly string FilePath;
         public readonly string Content;
@@ -206,7 +208,7 @@ public partial class YamlParserTests: IDisposable
         }
     }
 
-    internal class ScopeGuard<T>(Func<T> init , Action<T> disposeAction) : IDisposable
+    internal class ScopeGuard<T>(Func<T> init, Action<T> disposeAction) : IDisposable
     {
         private readonly Action<T> _disposeAction = disposeAction;
         private T _value = init();

--- a/test/YAYL.Tests/YamlParserTests.Polymorphic.cs
+++ b/test/YAYL.Tests/YamlParserTests.Polymorphic.cs
@@ -313,7 +313,7 @@ public partial class YamlParserTests
     abstract record SchemaType;
 
     record StringType(string Pattern) : SchemaType;
-    record RefType([property:YamlPropertyName("$ref")] string Ref) : SchemaType;
+    record RefType([property: YamlPropertyName("$ref")] string Ref) : SchemaType;
 
     [Fact]
     public void Parse_PolymorphicDefault_Success()

--- a/test/YAYL.Tests/YamlParserTests.cs
+++ b/test/YAYL.Tests/YamlParserTests.cs
@@ -473,7 +473,8 @@ public partial class YamlParserTests
     [Fact]
     public async Task Parse_VariableResolution_ScalarString_Success()
     {
-        _parser.AddVariableResolver(new Regex(@"\$\{([^}]+)\}"), (varName) => {
+        _parser.AddVariableResolver(new Regex(@"\$\{([^}]+)\}"), (varName) =>
+        {
             return varName == "name" ? "World" : varName;
         });
 
@@ -491,7 +492,8 @@ public partial class YamlParserTests
     [Fact]
     public async Task Parse_VariableResolution_NestedObject_Success()
     {
-        _parser.AddVariableResolver(new Regex(@"\$\{([^}]+)\}"), (varName) => {
+        _parser.AddVariableResolver(new Regex(@"\$\{([^}]+)\}"), (varName) =>
+        {
             return varName == "info" ? "NestedValue" : varName;
         });
 


### PR DESCRIPTION
This pull request introduces a significant refactor of the `YamlParser` class to enhance type conversion logic and streamline code readability. The changes include the introduction of a new type conversion system, the removal of redundant logic, and the addition of utility methods for handling YAML scalar values. Additionally, minor formatting adjustments were made in test files for consistency.

### Core Refactor: Type Conversion System
* Introduced a `TypeConverterFactory` to centralize and streamline type conversion logic, replacing scattered type parsing logic in `YamlParser`. (`src/YAYL/YamlParser.cs`, `src/YAYL/conversion/TypeConverterFactory.cs`, [[1]](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eL628-R628) [[2]](diffhunk://#diff-3e2df09cdfc5e7d9ab3a0d6d4a969dcc44e24f7c6f4b7fbe1b31af797a5a4fcbR1-R90)
* Added individual type converters (`TypeConverter<T>`, `EnumConverter`) to handle specific type parsing, including enums with normalized value names. (`src/YAYL/conversion/TypeConverter.cs`, `src/YAYL/conversion/EnumConverter.cs`, [[1]](diffhunk://#diff-94de1941a6625786bb623eac11ebaad5e6b123e8b41526b5ee53fdd2e81bdf4fR1-R27) [[2]](diffhunk://#diff-536cbfad21303c647139faf4cb391ace334c6c877abb4d9c1be2ff3de1275b6cR1-R14)
* Implemented an interface, `ITypeConverter`, to standardize type conversion behavior. (`src/YAYL/conversion/ITypeConverter.cs`, [src/YAYL/conversion/ITypeConverter.csR1-R15](diffhunk://#diff-869115c38026c8296883f51fbaf6b13e4243ffe87f8c7959b067eebbb1bf7275R1-R15))

### Code Simplification and Cleanup
* Removed redundant methods like `NormalizeEnumValueName` and inline logic for type parsing in favor of the new type conversion system. (`src/YAYL/YamlParser.cs`, [[1]](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eL73-L74) [[2]](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eL104-R106) [[3]](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eL724-R684)
* Replaced hardcoded null value checks with a utility method `GetValue` in `YAMLExtensions`, improving readability and reusability. (`src/YAYL/util/YAMLExtensions.cs`, [src/YAYL/util/YAMLExtensions.csR12-R22](diffhunk://#diff-5aa25f194507c86b7f0c8fd4ecb4981199811d6fda8de715d0f5c639a05a3099R12-R22))

### Utility Enhancements
* Added `GetValue` extension method for `YamlScalarNode` to handle null-like values consistently across the codebase. (`src/YAYL/util/YAMLExtensions.cs`, [src/YAYL/util/YAMLExtensions.csR12-R22](diffhunk://#diff-5aa25f194507c86b7f0c8fd4ecb4981199811d6fda8de715d0f5c639a05a3099R12-R22))

### Test Adjustments
* Reformatted lambda expressions in test files for consistent code style. (`test/YAYL.Tests/YamlParserTests.Files.cs`, `test/YAYL.Tests/YamlParserTests.cs`, [[1]](diffhunk://#diff-8d93867ca4dc497aeeb8650467899609d0a5d2bc4a7090dfea866adef5f79cbfL115-R121) [[2]](diffhunk://#diff-5e0ee8f447594108a92678f9ffe624d9dffbd739cae1cc3a8fe1c1c6ddec04f9L476-R477) [[3]](diffhunk://#diff-5e0ee8f447594108a92678f9ffe624d9dffbd739cae1cc3a8fe1c1c6ddec04f9L494-R496)