### PR TITLE
Added functionality to have a field presence test when deciding which default to use.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.8.1] - 2025-07-22
 
 - **YamlDerivedTypeDefaultAttribute:** Added functionality to have a field presence test when deciding which default to use.
+- **Added BigInteger:** Scalars can now be parsed into `BigInteger`.
 
 ## [1.8.0] - 2025-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.8.1] - 2025-07-22
+
+- **YamlDerivedTypeDefaultAttribute:** Added functionality to have a field presence test when deciding which default to use.
+
 ## [1.8.0] - 2025-07-10
 
 - **YamlVariantTypeDefaultAttribute:** Added attribute that allows adding a catch all to variant declarations.

--- a/src/YAYL/YamlParser.cs
+++ b/src/YAYL/YamlParser.cs
@@ -85,7 +85,7 @@ public class YamlParser(YamlNamingPolicy namingPolicy = YamlNamingPolicy.KebabCa
 
         if (discriminatorNode.Value is not YamlScalarNode typeNode)
         {
-            if (baseType.GetCustomAttribute<YamlDerivedTypeDefaultAttribute>() is { DerivedType: var defaultDerivedType })
+            if (baseType.GetCustomAttributes<YamlDerivedTypeDefaultAttribute>().FirstOrDefault(x => x.FieldToTest is null || node.ContainsField(x.FieldToTest)) is { DerivedType: var defaultDerivedType })
             {
                 if (defaultDerivedType.IsAbstract)
                 {

--- a/src/YAYL/attributes/YamlDerivedTypeDefaultAttribute.cs
+++ b/src/YAYL/attributes/YamlDerivedTypeDefaultAttribute.cs
@@ -2,10 +2,11 @@ using System;
 
 namespace YAYL.Attributes;
 
-[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 public class YamlDerivedTypeDefaultAttribute(Type derivedType) : Attribute
 {
     public Type DerivedType { get; } = derivedType;
+    public string? FieldToTest { get; init; }
 
     public void Deconstruct(out Type derivedType)
     {

--- a/src/YAYL/conversion/TypeConverterFactory.cs
+++ b/src/YAYL/conversion/TypeConverterFactory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Numerics;
 using System.Threading;
 using YamlDotNet.RepresentationModel;
 
@@ -19,6 +20,7 @@ internal class TypeConverterFactory
         new TypeConverter<float>((s, _) => float.Parse(s)),
         new TypeConverter<decimal>((s, _) => decimal.Parse(s)),
         new TypeConverter<Guid>((s, _) => Guid.Parse(s)),
+        new TypeConverter<BigInteger>((s, _) => BigInteger.Parse(s)),
         new TypeConverter<DateTime>((s, _) => DateTime.Parse(s)),
         new TypeConverter<DateTimeOffset>((s, _) => DateTimeOffset.Parse(s)),
         new TypeConverter<TimeSpan>((s, _) => TimeSpan.Parse(s)),

--- a/src/YAYL/util/YAMLExtensions.cs
+++ b/src/YAYL/util/YAMLExtensions.cs
@@ -20,4 +20,9 @@ internal static class YAMLExtensions
         }
         return node.Value;
     }
+
+    public static bool ContainsField(this YamlMappingNode mapping, string fieldName)
+    {
+        return mapping.Children.ContainsKey(new YamlScalarNode(fieldName));
+    }
 }


### PR DESCRIPTION
This pull request introduces enhancements to the `YamlDerivedTypeDefaultAttribute` functionality, enabling field-based polymorphic default type resolution in YAML parsing. It also includes corresponding updates to the attribute's implementation, utility methods, and test coverage.

### Enhancements to `YamlDerivedTypeDefaultAttribute`:

* Modified `YamlDerivedTypeDefaultAttribute` to support multiple instances on a single class and added a new optional `FieldToTest` property for field-based default resolution. (`src/YAYL/attributes/YamlDerivedTypeDefaultAttribute.cs`, [src/YAYL/attributes/YamlDerivedTypeDefaultAttribute.csL5-R9](diffhunk://#diff-0658941b343fb958c846bdae44a2da769bce37340759b61057ed4ee1487fae70L5-R9))
* Updated the `AddVariableResolver` logic in `YamlParser` to use `FieldToTest` for determining the appropriate default type when a specific field is present. (`src/YAYL/YamlParser.cs`, [src/YAYL/YamlParser.csL88-R88](diffhunk://#diff-b5c18c420e98d20fbb82ce5baf09c80bf4cf326cadcb88594f59caa389c1cb6eL88-R88))

### Utility Method Addition:

* Added a `ContainsField` extension method for `YamlMappingNode` to check for the presence of a specific field, supporting the new `FieldToTest` functionality. (`src/YAYL/util/YAMLExtensions.cs`, [src/YAYL/util/YAMLExtensions.csR23-R27](diffhunk://#diff-5aa25f194507c86b7f0c8fd4ecb4981199811d6fda8de715d0f5c639a05a3099R23-R27))

### Test Coverage:

* Added extensive test cases to validate the new functionality, including scenarios with multiple defaults, explicit types, and fallback behaviors. (`test/YAYL.Tests/YamlParserTests.Polymorphic.cs`, [test/YAYL.Tests/YamlParserTests.Polymorphic.csR337-R495](diffhunk://#diff-0a50476c5531e873bb7f2e8eb5995d1463a0d404b5bc134c23c60e46b5003916R337-R495))

### Documentation Update:

* Updated the `CHANGELOG.md` to reflect the new `YamlDerivedTypeDefaultAttribute` functionality with field presence tests. (`CHANGELOG.md`, [CHANGELOG.mdR3-R6](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R6))