### PR TITLE
Adding support for regexes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.9.0] - 2025-08-16
+
+- **Added support for Regex:** Regex fields can now be parsed.
+
 ## [1.8.2] - 2025-07-25
 
 - **Fix parser performance:** Fixing issue that was causing performance degradation when converting using type inference.

--- a/src/YAYL/conversion/TypeConverterFactory.cs
+++ b/src/YAYL/conversion/TypeConverterFactory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Numerics;
+using System.Text.RegularExpressions;
 using System.Threading;
 using YamlDotNet.RepresentationModel;
 
@@ -24,6 +25,7 @@ internal class TypeConverterFactory
         new TypeConverter<DateTime>((s, _) => (DateTime.TryParse(s, out var v), v)),
         new TypeConverter<DateTimeOffset>((s, _) => (DateTimeOffset.TryParse(s, out var v), v)),
         new TypeConverter<TimeSpan>((s, _) => (TimeSpan.TryParse(s, out var v), v)),
+        new TypeConverter<Regex>((s, _) => (true, new Regex(s))),
         new EnumConverter(),
     ];
 

--- a/test/YAYL.Tests/YamlParserTests.cs
+++ b/test/YAYL.Tests/YamlParserTests.cs
@@ -505,4 +505,16 @@ public partial class YamlParserTests
         Assert.NotNull(result);
         Assert.Equal("Value is NestedValue", result.Nested.Info);
     }
+
+    record ObjectWithRegex(Regex Pattern);
+
+    [Fact]
+    public void Parse_RegexProperty_Success()
+    {
+        var yaml = "pattern: ^[a-zA-Z0-9]+$";
+        var result = _parser.Parse<ObjectWithRegex>(yaml);
+        Assert.NotNull(result);
+        Assert.NotNull(result.Pattern);
+        Assert.Equal("^[a-zA-Z0-9]+$", result.Pattern.ToString());
+    }
 }


### PR DESCRIPTION
This pull request adds support for parsing `Regex` fields in the project. The main changes include updating the type converter factory to handle `Regex` types and adding a corresponding test to ensure correct parsing. The changelog was also updated to reflect this new feature.

**Regex support:**

* Added `Regex` type support to the `TypeConverterFactory` by introducing a new `TypeConverter<Regex>` that constructs a `Regex` from a string.
* Imported `System.Text.RegularExpressions` in `TypeConverterFactory.cs` to enable regex handling.

**Testing:**

* Added a new test `Parse_RegexProperty_Success` in `YamlParserTests.cs` to verify that regex fields are parsed correctly from YAML.

**Documentation:**

* Updated `CHANGELOG.md` to document the addition of regex parsing support in version 1.9.0.